### PR TITLE
Fix pattern invalidation performance

### DIFF
--- a/src/main/java/com/YTrollman/CreativeCrafter/CreativeCrafter.java
+++ b/src/main/java/com/YTrollman/CreativeCrafter/CreativeCrafter.java
@@ -25,38 +25,18 @@ import net.minecraftforge.fml.loading.FMLPaths;
 public class CreativeCrafter {
     public static final String MOD_ID = "creativecrafter";
     public static final Logger LOGGER = LogManager.getLogger(MOD_ID);
-    
+
+    public static final int ROWS = 12;
+    public static final int SIZE = ROWS * 9;
+
     public CreativeCrafter() {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(ModSetup::init);
         DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
             FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientEventHandler::init);
         });
-        
-        MinecraftForge.EVENT_BUS.register(this);
-        
+
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, Config.client_config);
-        
-        RegistryHandler.init();
-        
         Config.loadConfig(Config.client_config, FMLPaths.CONFIGDIR.get().resolve("creativecrafter-client.toml").toString());
-        
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::doClientStuff);
-    }
-
-    private void setup(final FMLCommonSetupEvent event)
-    {
-    	
-    }
-
-    private void doClientStuff(final FMLClientSetupEvent event) 
-    {
-    	
-    }
-
-    @SubscribeEvent
-    public void onServerStarting(FMLServerStartingEvent event) 
-    {
-    	
+        RegistryHandler.init();
     }
 }

--- a/src/main/java/com/YTrollman/CreativeCrafter/container/CreativeCrafterContainer.java
+++ b/src/main/java/com/YTrollman/CreativeCrafter/container/CreativeCrafterContainer.java
@@ -1,5 +1,6 @@
 package com.YTrollman.CreativeCrafter.container;
 
+import com.YTrollman.CreativeCrafter.CreativeCrafter;
 import com.YTrollman.CreativeCrafter.registry.ModContainers;
 import com.YTrollman.CreativeCrafter.tileentity.CreativeCrafterTileEntity;
 import com.refinedmods.refinedstorage.container.BaseContainer;
@@ -16,7 +17,7 @@ public class CreativeCrafterContainer extends BaseContainer
         super(ModContainers.CREATIVE_CRAFTER_CONTAINER.get(),tile, player, windowId);
         this.tile = tile;
 
-        for(int i = 0; i < 12; i++)
+        for(int i = 0; i < CreativeCrafter.ROWS; i++)
             for(int j = 0; j < 9; j++)
                 addSlot(new SlotItemHandler(tile.getNode().getPatternItems(), (i * 9) + j, 8 + (18 * j), 20 + (18 * i)));
 


### PR DESCRIPTION
This basically replicates https://github.com/Edivad99/ExtraStorage/pull/27, which fixes exact same issue for tiered crafters, only my code is slightly different but the idea of only recreating the pattern that changed instead of the whole list is the smae.

If you shift-click patterns into a nearly full crafter (especially if you have that mod that allows you to hold shift and move mouse), you get a huge tps (and before recent RS fixes a client freeze as well) lagspike, because each pattern insertion invalidates and recreates all of them, and pattern recreation is pretty expensive in modpacks with bagillion recipes.
This is an issue even in original RS code (from where both this and tiered crafters code was obviously copied), but for RS it's unnoticeable since their crafters have only 9 pattern slots, and with more slots the lag scales rapidly.

