### PR TITLE
Fix pattern invalidation fix

### DIFF
--- a/src/main/java/com/YTrollman/CreativeCrafter/node/CreativeCrafterNetworkNode.java
+++ b/src/main/java/com/YTrollman/CreativeCrafter/node/CreativeCrafterNetworkNode.java
@@ -76,7 +76,7 @@ public class CreativeCrafterNetworkNode extends NetworkNode implements ICrafting
             {
                 if (!world.isClientSide)
                     invalidateSlot(slot);
-                invalidateNextTick = false;
+                invalidateNextTick = true;
             }
         });
 


### PR DESCRIPTION
Oh my god I had a last-minute derp and put `false` instead of `true` there somehow, so crafting manager is never notified that it should ask for the updated list of patterns from crafters.

Version 0.14 that you already released (oof) is borked, you should disable it on curse 